### PR TITLE
Fix build failure with latest Rust nightly

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -16,6 +16,7 @@ use base::{TCFType, kCFAllocatorDefault};
 
 use libc::c_void;
 use std::mem;
+use std::num::{FromPrimitive, ToPrimitive};
 
 pub type CFNumberType = u32;
 


### PR DESCRIPTION
`{From, To}Primitive` are no longer in the predule.

These traits are likely to be removed entirely so perhaps we should not impl them at all.