### PR TITLE
Use libc from crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ authors = ["The Servo Project Developers"]
 
 name = "core_foundation"
 crate-type = ["rlib"]
+
+[dependencies]
+libc = "*"


### PR DESCRIPTION
Required to make glutin compile on os/x.