### PR TITLE
Update for stable Rust by removing the core feature

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -178,7 +178,6 @@ extern {
 #[test]
 fn should_box_and_unbox() {
     use number::{CFNumber, number};
-    use std::num::ToPrimitive;
 
     let arr = CFArray::from_CFTypes(&[
         number(1).as_CFType(),
@@ -189,18 +188,18 @@ fn should_box_and_unbox() {
     ]);
 
     unsafe {
-        let mut sum = 0i32;
+        let mut sum = 0;
 
         for elem in arr.iter() {
             let number: CFNumber = TCFType::wrap_under_get_rule(mem::transmute(elem));
-            sum += number.to_i32().unwrap()
+            sum += number.to_i64().unwrap()
         }
 
         assert!(sum == 15);
 
         for elem in arr.iter() {
             let number: CFNumber = TCFType::wrap_under_get_rule(mem::transmute(elem));
-            sum += number.to_i32().unwrap()
+            sum += number.to_i64().unwrap()
         }
 
         assert!(sum == 30);

--- a/src/base.rs
+++ b/src/base.rs
@@ -8,7 +8,6 @@
 // except according to those terms.
 
 use libc::{c_long, c_ulong, c_uint};
-use std::num::Int;
 
 pub type Boolean = u8;
 
@@ -26,7 +25,7 @@ pub trait CFIndexConvertible {
 impl CFIndexConvertible for usize {
     #[inline]
     fn to_CFIndex(self) -> CFIndex {
-        let max_CFIndex: CFIndex = Int::max_value();
+        let max_CFIndex = CFIndex::max_value();
         if self > (max_CFIndex as usize) {
             panic!("value out of range")
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,6 @@
 
 #![allow(non_snake_case)]
 
-#![feature(core)]
-
 extern crate libc;
 
 #[cfg(target_os="macos")]

--- a/src/number.rs
+++ b/src/number.rs
@@ -16,7 +16,6 @@ use base::{TCFType, kCFAllocatorDefault};
 
 use libc::c_void;
 use std::mem;
-use std::num::{FromPrimitive, ToPrimitive};
 
 pub type CFNumberType = u32;
 
@@ -93,66 +92,49 @@ impl TCFType<CFNumberRef> for CFNumber {
 }
 
 // TODO(pcwalton): Floating point.
-impl ToPrimitive for CFNumber {
+impl CFNumber {
     #[inline]
-    fn to_i64(&self) -> Option<i64> {
+    pub fn to_i64(&self) -> Option<i64> {
         unsafe {
             let mut value: i64 = 0;
             let ok = CFNumberGetValue(self.obj, kCFNumberSInt64Type, mem::transmute(&mut value));
-            assert!(ok);
-            Some(value)
+            if ok { Some(value) } else { None }
         }
     }
 
     #[inline]
-    fn to_u64(&self) -> Option<u64> {
-        // CFNumber does not support unsigned 64-bit values.
-        None
-    }
-
-    #[inline]
-    fn to_f64(&self) -> Option<f64> {
+    pub fn to_f64(&self) -> Option<f64> {
         unsafe {
             let mut value: f64 = 0.0;
             let ok = CFNumberGetValue(self.obj, kCFNumberFloat64Type, mem::transmute(&mut value));
-            assert!(ok);
-            Some(value)
+            if ok { Some(value) } else { None }
         }
     }
-}
 
-// TODO(pcwalton): Floating point.
-impl FromPrimitive for CFNumber {
     #[inline]
-    fn from_i64(value: i64) -> Option<CFNumber> {
+    pub fn from_i64(value: i64) -> CFNumber {
         unsafe {
             let number_ref = CFNumberCreate(kCFAllocatorDefault,
                                             kCFNumberSInt64Type,
                                             mem::transmute(&value));
-            Some(TCFType::wrap_under_create_rule(number_ref))
+            TCFType::wrap_under_create_rule(number_ref)
         }
     }
 
     #[inline]
-    fn from_u64(_: u64) -> Option<CFNumber> {
-        // CFNumber does not support unsigned 64-bit values.
-        None
-    }
-
-    #[inline]
-    fn from_f64(value: f64) -> Option<CFNumber> {
+    pub fn from_f64(value: f64) -> CFNumber {
         unsafe {
             let number_ref = CFNumberCreate(kCFAllocatorDefault,
                                             kCFNumberFloat64Type,
                                             mem::transmute(&value));
-            Some(TCFType::wrap_under_create_rule(number_ref))
+            TCFType::wrap_under_create_rule(number_ref)
         }
     }
 }
 
 /// A convenience function to create CFNumbers.
 pub fn number(value: i64) -> CFNumber {
-    FromPrimitive::from_i64(value).unwrap()
+    CFNumber::from_i64(value)
 }
 
 #[link(name = "CoreFoundation", kind = "framework")]

--- a/src/string.rs
+++ b/src/string.rs
@@ -475,5 +475,5 @@ fn string_and_back() {
     let original = "The quick brown fox jumped over the slow lazy dog.";
     let cfstr = CFString::from_static_string(original);
     let converted = cfstr.to_string();
-    assert!(original == converted.as_slice());
+    assert!(converted == original);
 }

--- a/src/url.rs
+++ b/src/url.rs
@@ -240,5 +240,5 @@ fn file_url_from_path() {
     let path = "/usr/local/foo/";
     let cfstr_path = CFString::from_static_string(path);
     let cfurl = CFURL::from_file_system_path(cfstr_path, kCFURLPOSIXPathStyle, true);
-    assert!("file:///usr/local/foo/" == cfurl.get_string().to_string().as_slice());
+    assert!(cfurl.get_string().to_string() == "file:///usr/local/foo/");
 }


### PR DESCRIPTION
It'd be great for libraries that depend on this crate if it worked on stable Rust. With the beta approaching soon, the unstable and deprecated APIs this crate uses are:
* `std::num::ToPrimitive` and `std::num::FromPrimitive`
* `std::num::Int::max_value`
* `std::str::Str::as_slice`

This pull request replaces uses of this functionality.

The changes to `CFNumber` are a breaking change, but I only found servo/rust-core-text and servo/rust-azure that would be impacted, and the fix is simple.