### PR TITLE
Update for rust beta

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -29,7 +29,7 @@ pub type CFArrayEqualCallBack = *const u8;
 
 #[allow(dead_code)]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Clone, Copy)]
 pub struct CFArrayCallBacks {
     version: CFIndex,
     retain: CFArrayRetainCallBack,

--- a/src/base.rs
+++ b/src/base.rs
@@ -37,7 +37,7 @@ pub type CFOptionFlags = u32;
 
 #[allow(dead_code)]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Clone, Copy)]
 pub struct CFRange {
     location: CFIndex,
     length: CFIndex

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -25,7 +25,7 @@ pub type CFDictionaryRetainCallBack = *const u8;
 
 #[allow(dead_code)]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Clone, Copy)]
 pub struct CFDictionaryKeyCallBacks {
     version: CFIndex,
     retain: CFDictionaryRetainCallBack,
@@ -37,7 +37,7 @@ pub struct CFDictionaryKeyCallBacks {
 
 #[allow(dead_code)]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Clone, Copy)]
 pub struct CFDictionaryValueCallBacks {
     version: CFIndex,
     retain: CFDictionaryRetainCallBack,

--- a/src/set.rs
+++ b/src/set.rs
@@ -23,7 +23,7 @@ pub type CFSetHashCallBack = *const u8;
 
 #[allow(dead_code)]
 #[repr(C)]
-#[derive(Copy)]
+#[derive(Clone, Copy)]
 pub struct CFSetCallBacks {
     version: CFIndex,
     retain: CFSetRetainCallBack,


### PR DESCRIPTION
Now, `Copy` is subtrait of `Clone`.